### PR TITLE
Add Headers and IsBase64Encoded fields to Response struct

### DIFF
--- a/ch4/version1/main.go
+++ b/ch4/version1/main.go
@@ -5,8 +5,10 @@ import (
 )
 
 type Response struct {
-	StatusCode int    `json:"statusCode"`
-	Body       string `json:"body"`
+	StatusCode      int               `json:"statusCode"`
+	Headers         map[string]string `json:"headers"`
+	Body            string            `json:"body"`
+	IsBase64Encoded bool              `json:"isBase64Encoded,omitempty"`
 }
 
 func handler() (Response, error) {


### PR DESCRIPTION
The custom Response struct used in this example must include the **Headers** and **IsBase64Encoded** fields even if you don't populate them in the return of the handler. Otherwise, you get a _Execution failed due to configuration error: Malformed Lambda proxy response_ in the logs.